### PR TITLE
Create consistent lower case for scanner options

### DIFF
--- a/examples/pyscannerbit_hds_interface.py
+++ b/examples/pyscannerbit_hds_interface.py
@@ -36,13 +36,13 @@ for s in scanners:
                              polychord_tol=1.0,
                              polychord_nlive=20,
                              diver_convthresh=1e-2,
-                             diver_NP=300,
+                             diver_np=300,
                              twalk_sqrtr=1.05,
                              random_point_number=10000,
                              toy_mcmc_point_number=10,
                              badass_points=1000,
                              badass_jumps=10,
-                             pso_NP=400)
+                             pso_np=400)
     experiment = hds.OptimisationExperiment(procedure, './hds')
     feeder = hds.functions.FunctionFeeder()
     feeder.load_function('Rastrigin', {'dimensionality': 3})

--- a/high_dimensional_sampling/optimisation/pyscannerbit.py
+++ b/high_dimensional_sampling/optimisation/pyscannerbit.py
@@ -39,13 +39,13 @@ class PyScannerBit(hds.Procedure):
                                  'polychord_tol',
                                  'polychord_nlive',
                                  'diver_convthresh',
-                                 'diver_NP',
+                                 'diver_np',
                                  'twalk_sqrtr',
                                  'random_point_number',
                                  'toy_mcmc_point_number',
                                  'badass_points',
                                  'badass_jumps',
-                                 'pso_NP']
+                                 'pso_np']
 
         # Check if import was succesfull
         # Raise Error if this fails (not all necessary packages are available)
@@ -80,14 +80,14 @@ class PyScannerBit(hds.Procedure):
         scanner_options["polychord"] = {"tol": self.polychord_tol,
                                         "nlive": self.polychord_nlive}
         scanner_options["diver"] = {"convthresh": self.diver_convthresh,
-                                    "NP": self.diver_np}
-        scanner_options["twalk"] = {"sqrtR": self.twalk_sqrtr}
+                                    "np": self.diver_np}
+        scanner_options["twalk"] = {"sqrtr": self.twalk_sqrtr}
         scanner_options["random"] = {"point_number": self.random_point_number}
         scanner_options["toy_mcmc"] = {"point_number":
                                        self.toy_mcmc_point_number}
         scanner_options["badass"] = {"points": self.badass_points,
                                      "jumps": self.badass_jumps}
-        scanner_options["pso"] = {"NP": self.pso_np}
+        scanner_options["pso"] = {"np": self.pso_np}
 
         # Get ranges of the test function. The 0.001 moves the minima 0.001 up
         # and the maxima 0.001 down, in order to make use the sampling is not


### PR DESCRIPTION
@bstienen At some point a case mismatch arose within the Pyscannerbit interface. I assume you would prefer lower case here. Let me know if something else is preferred.