### PR TITLE
Solution to the invert issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
+## Unreleased
+
+### Fixed
+
+* When using the `invert` method on a wrapped function, the original function
+  was also inverted. This was solved by having the `get_simple_interface()`
+  and `get_simple_interface_with_scan` methods use copies of the original
+  function.
+
 ## Version 0.2.0 (Monday February 17th, 2020)
 
 ### Added
+
 * A submodule `results` that implements functionality to visualise or format
   the results of one or more experiments into neat little plots and tables.
   Accompanying this new submodule is a new example script.
@@ -32,6 +42,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 * Several optimisation procedures were added.
 
 ### Changed
+
 * The examples now use relative path indications for storage of their results,
   so that the examples can be used out of the box without errors.
 * The package indicator in setup.py now is more general, allowing for easier
@@ -44,6 +55,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
   in the FunctionFeeder.
 
 ### Fixed
+
 * An error was raised when GaussianShells was logged, as this function stores
   its parameters internally as numpy arrays. These don't translate well to
   .yaml files. This has been solved by forcing the storage of function 
@@ -53,9 +65,11 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
   work with dataframes now, as was intended.
   
 ---
+
 ## Version 0.1.1 (Tuesday August 20th, 2019)
 
 ### Added
+
 * A `get_ranges` method in the TestFunction class. It returns the ranges of the
   test function, taking a leeway parameter epsilon provided to the method into
   account: all minima will be raised by epsilon, all maxima will be reduced by
@@ -73,15 +87,18 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
   the logged time includes also the overhead introduced by the HDS package
   itself.
 * The following test functions are added:
-    * BreitWigner
-    * Reciprocal
+
+  * BreitWigner
+  * Reciprocal
 
 ### Changed
+
 * Increased the readability of the error message given when a test function is
   queried for its value outside of the box defined by its ranges parameter.
 * The `utils.get_time` method now returns time in seconds
 
 ### Fixed
+
 * Ackley, Easom and Sphere test functions returned data in an incorrect shape.
   This has been corrected.
 * The GaussianShells test function mapped multi-point input to a single output

--- a/high_dimensional_sampling/functions.py
+++ b/high_dimensional_sampling/functions.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import os
+from copy import deepcopy
 
 import numpy as np
 import pandas as pd
@@ -394,7 +395,7 @@ class SimpleFunctionWrapper:
         if not isinstance(function, TestFunction):
             raise Exception("SimpleFunctionWrapper can only wrap instances of"
                             "the TestFunction class.")
-        self.function = function
+        self.function = deepcopy(function)
 
     def __call__(self, *args, **kwargs):
         """
@@ -490,7 +491,7 @@ class SimpleFunctionWrapper:
         """ Invert evaluations of the TestFunction (i.e. multiply them with
         -1). See documentation for TestFunction.invert() for more information.
         """
-        return self.function.invert()
+        return self.function.invert(inverted)
 
 
 class SimpleFunctionWrapperWithScan(SimpleFunctionWrapper):

--- a/tests/test_testfunction.py
+++ b/tests/test_testfunction.py
@@ -245,7 +245,7 @@ def test_simplefunctionwrapper_call():
     z_evaluated = wrapped(x[:, 0], x[:, 1], x[:, 2])
     wrapped.invert()
     assert np.array_equal(z_evaluated, -1*wrapped(x[:, 0], x[:, 1], x[:, 2]))
-    tmp.invert(False)
+    wrapped.invert(False)
     assert np.array_equal(z_evaluated, wrapped(x[:, 0], x[:, 1], x[:, 2]))
     # Test what happens when just numbers are provided
     z = wrapped._create_input_array([1, 2, 3])
@@ -286,4 +286,20 @@ def test_return_wrapper():
     tmp = TmpFunction()
     tmp_wrapped = tmp.get_simple_interface()
     assert isinstance(tmp_wrapped, func.SimpleFunctionWrapper)
-    assert tmp == tmp_wrapped.function
+    assert isinstance(tmp, type(tmp_wrapped.function))
+
+
+def test_invertion():
+    tmp = TmpFunction()
+    tmp_wrapped = tmp.get_simple_interface()
+    x = np.random.rand(1, 2)
+
+    y_normal = tmp(x)
+    y_wrapped_normal = tmp_wrapped(x[:, 0], x[:, 1])
+    tmp_wrapped.invert()
+    y_normal_inverted = tmp(x)
+    y_wrapped_inverted = tmp_wrapped(x[:, 0], x[:, 1])
+
+    assert np.array_equal(y_wrapped_normal, y_normal)
+    assert np.array_equal(y_normal, -y_wrapped_inverted)
+    assert np.array_equal(y_normal, y_normal_inverted)


### PR DESCRIPTION
This pull request solves the issue with the `inverse()` functionality as explained in #30. It does this by explicitly making a copy of the original function instead of storing a reference to this original function.