### PR TITLE
Setup pygmo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,23 @@
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
+## Unreleased
+
+## Added
+
+### Changed
+
+* As `pygmo` cannot be installed through the pip installer, it has been
+  removed from installation requirements in the `setup.py` file. This will only
+  yield error messages when the `pygmo` package is actually requested by the
+  implemented pygmo Procedure.
+
+### Fixed
+
 ## Version 0.2.0 (Monday February 17th, 2020)
 
 ### Added
+
 * A submodule `results` that implements functionality to visualise or format
   the results of one or more experiments into neat little plots and tables.
   Accompanying this new submodule is a new example script.
@@ -32,6 +46,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 * Several optimisation procedures were added.
 
 ### Changed
+
 * The examples now use relative path indications for storage of their results,
   so that the examples can be used out of the box without errors.
 * The package indicator in setup.py now is more general, allowing for easier
@@ -44,6 +59,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
   in the FunctionFeeder.
 
 ### Fixed
+
 * An error was raised when GaussianShells was logged, as this function stores
   its parameters internally as numpy arrays. These don't translate well to
   .yaml files. This has been solved by forcing the storage of function 
@@ -53,9 +69,11 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
   work with dataframes now, as was intended.
   
 ---
+
 ## Version 0.1.1 (Tuesday August 20th, 2019)
 
 ### Added
+
 * A `get_ranges` method in the TestFunction class. It returns the ranges of the
   test function, taking a leeway parameter epsilon provided to the method into
   account: all minima will be raised by epsilon, all maxima will be reduced by
@@ -73,15 +91,18 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
   the logged time includes also the overhead introduced by the HDS package
   itself.
 * The following test functions are added:
-    * BreitWigner
-    * Reciprocal
+
+  * BreitWigner
+  * Reciprocal
 
 ### Changed
+
 * Increased the readability of the error message given when a test function is
   queried for its value outside of the box defined by its ranges parameter.
 * The `utils.get_time` method now returns time in seconds
 
 ### Fixed
+
 * Ackley, Easom and Sphere test functions returned data in an incorrect shape.
   This has been corrected.
 * The GaussianShells test function mapped multi-point input to a single output

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
     test_suite='tests',
-    install_requires=['pyyaml', 'numpy', 'pandas', 'matplotlib', 'seaborn', 'pygmo', 'gpyopt', 'cma'],  # FIXME: add your package's dependencies to this list
+    install_requires=['pyyaml', 'numpy', 'pandas', 'matplotlib', 'seaborn', 'gpyopt', 'cma'],  # FIXME: add your package's dependencies to this list
     setup_requires=[
     #    # dependency for `python setup.py test`
         'pytest-runner',


### PR DESCRIPTION
The `pygmo` package cannot be installed through pip, so including it in the `setup.py` file will result in errors when the package is installed in a clean environment. As `pygmo` is only used in one specific `Procedure` -- one that incidentally already *checks* if `pygmo` is installed -- this pull request removes `pygmo` from the installation requirements.