### PR TITLE
Particlefilter fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   documentation of __init__ of the Experiment class for more information.
 * The dimensionality of hidden `TestFunction`s can now be changed with the
   `dimensionality` argument at initialisation of the class.
+* The ParticleFilter now implements a callback method that allows for the
+  inclusion of a callback function in each sampling iteration (except for
+  the first one). See the documentation on the wiki and in the docstring for
+  more information.
 
 ### Changed
 
@@ -30,7 +34,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   changed.
 * To accomodate the implementation of callbacks in the particle filter, the
   selector methods don't select data directly, but instead output `(indices,
-  samples, values)`, where `indices` are the indices of the samples and values selected.
+  samples, values)`, where `indices` are the indices of the samples and values
+  selected.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * The `weighing_deterministic_linear` function in the particle filter's linear
   function was based on sample order, not on function value. This has been
   changed.
+* To accomodate the implementation of callbacks in the particle filter, the
+  selector methods don't select data directly, but instead output `(indices,
+  samples, values)`, where `indices` are the indices of the samples and values selected.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   results. As the output represents standard deviations, this is unexpected
   behaviour. The absolute value of the standard deviation is now returned
   instead.
+* The particle filter did not implement a way to keep the best points of the
+  previous iteration for the current one. This is now implemented through the
+  `survival_rate` argument (default=0.2).
 
 ## Version 0.2.0 (Monday February 17th, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   removed from installation requirements in the `setup.py` file. This will only
   yield error messages when the `pygmo` package is actually requested by the
   implemented pygmo Procedure.
+* The `weighing_deterministic_linear` function in the particle filter's linear
+  function was based on sample order, not on function value. This has been
+  changed.
 
 ### Fixed
 

--- a/high_dimensional_sampling/optimisation/particlefilter.py
+++ b/high_dimensional_sampling/optimisation/particlefilter.py
@@ -133,7 +133,7 @@ class ParticleFilter(hds.Procedure):
             x, y = self.sample_iteration(function)
         # Save points from previous iteration
         x, y = self.append_surviver_points(x, y, self.previous_samples,
-                                           self.survival_rate) 
+                                           self.survival_rate)
         self.iteration += 1
         self.previous_samples = (x, y)
         return (x, y)

--- a/high_dimensional_sampling/optimisation/particlefilter.py
+++ b/high_dimensional_sampling/optimisation/particlefilter.py
@@ -144,9 +144,11 @@ class ParticleFilter(hds.Procedure):
 
     def sample_iteration(self, function):
         # Select points to use as seed for gaussian
-        selected, values = self.selector_function(self, self.iteration_size,
-                                                  self.previous_samples[0],
-                                                  self.previous_samples[1])
+        ind, samples, values = self.selector_function(self, self.iteration_size,
+                                                      self.previous_samples[0],
+                                                      self.previous_samples[1])
+        selected = samples[ind]
+        values = values[ind]
         # Determine sigmas for gaussians
         stdevs = self.gaussian_constructor(self, selected, values)
         # Sample from gaussians
@@ -322,12 +324,12 @@ def selector_deterministic_linear(algorithm, n, samples, values):
     indices = []
     for i in range(len(samples_per_ind)):
         indices.extend([i]*int(samples_per_ind[i]))
-    return (samples[indices], values[indices])
+    return (indices, samples, values)
 
 
 def selector_stochastic_uniform(algorithm, n, samples, values):
     indices = np.random.choice(len(samples), n)
-    return (samples[indices], values[indices])
+    return (indices, samples, values)
 
 
 def selector_stochastic_linear(algorithm, n, samples, values):
@@ -338,14 +340,14 @@ def selector_stochastic_linear(algorithm, n, samples, values):
     else:
         probabilities = np.ones(len(z))/len(z)
     indices = np.random.choice(len(samples), n, p=probabilities.flatten())
-    return (samples[indices], values[indices])
+    return (indices, samples, values)
 
 
 def selector_stochastic_softmax(algorithm, n, samples, values):
     z = values - np.amin(values)
     probabilities = np.exp(-z) / np.sum(np.exp(-z))
     indices = np.random.choice(len(samples), n, p=probabilities)
-    return (samples[indices], values[indices])
+    return (indices, samples, values)
 
 
 class ExampleFunction(func.TestFunction):

--- a/high_dimensional_sampling/optimisation/particlefilter.py
+++ b/high_dimensional_sampling/optimisation/particlefilter.py
@@ -46,10 +46,10 @@ class ParticleFilter(hds.Procedure):
             iteration_size: Number of samples to add in each iteration.
                 Default: 1000.
             survival_rate: Defines how many points of the previous iteration
-                will be copied over to the current iteration. This fraction will
-                be taken as the best points sampled from the previous iteration
-                (i.e., 'the survival_rate% best points will be kept). Has to be
-                a `float`. Default is 0.2.
+                will be copied over to the current iteration. This fraction
+                will be taken as the best points sampled from the previous
+                iteration (i.e., 'the survival_rate% best points will be kept).
+                Has to be a `float`. Default is 0.2.
             selector_function: Function to sample points from previous samples.
                 Default: `self.selector_deterministic_linear`.
             width: Start width parameter for the gaussians. Default: 2.
@@ -61,14 +61,14 @@ class ParticleFilter(hds.Procedure):
                 gaussians to use. Default: `gaussian_constructor_linear`.
             inf_replace: Number to replace infinities in ranges with.
                 Default: 1e9.
-            callback: Handle to a function that will be called at each iteration
-                (except the first one). This function needs to have the
-                following signature: (
+            callback: Handle to a function that will be called at each
+                iteration (except the first one). This function needs to have
+                the following signature: (
                     reference to the ParticleFilter object,
                     indices of selected samples from previous iteration,
                     samples from previous iteration
                     function values from previous iteration,
-                    standard deviations for selected points (see indices) from 
+                    standard deviations for selected points (see indices) from
                         gaussian constructor,
                     used width to create standard deviations,
                     newly sampled points x,
@@ -132,7 +132,8 @@ class ParticleFilter(hds.Procedure):
             # Sample new iteration with gaussian kernel
             x, y = self.sample_iteration(function)
         # Save points from previous iteration
-        self.append_surviver_points(x, y, self.previous_samples, self.survival_rate)
+        self.append_surviver_points(x, y, self.previous_samples,
+                                    self.survival_rate)
         self.iteration += 1
         self.previous_samples = (x, y)
         return (x, y)
@@ -172,7 +173,8 @@ class ParticleFilter(hds.Procedure):
 
     def sample_iteration(self, function):
         # Select points to use as seed for gaussian
-        ind, samples, values = self.selector_function(self, self.iteration_size,
+        ind, samples, values = self.selector_function(self,
+                                                      self.iteration_size,
                                                       self.previous_samples[0],
                                                       self.previous_samples[1])
         # Determine sigmas for gaussians
@@ -184,13 +186,12 @@ class ParticleFilter(hds.Procedure):
                 x[:, i] = self._sample_iteration_hard(samples[:, i],
                                                       stdevs[:, i], r[0], r[1])
             else:
-                x[:, i] = self._sample_iteration_soft(samples[:, i],
-                                                      stdevs[:, i])
+                x[:, i] = self._sample_iteration_soft(samples[:, i], stdevs[:,
+                                                                            i])
         y = function(x)
         if hasattr(self.callback, '__call__'):
-            self.callback(self, ind, samples, values,
-                          stdevs, algorithm.determine_gaussian_width(),
-                          x, y)
+            self.callback(self, ind, samples, values, stdevs,
+                          algorithm.determine_gaussian_width(), x, y)
         return (x, y)
 
     def _sample_iteration_soft(self, means, stdevs):
@@ -204,20 +205,20 @@ class ParticleFilter(hds.Procedure):
                                        loc=mean,
                                        scale=stdev)
         return x
-    
+
     def append_surviver_points(self, x, y, previous_samples, survival_rate):
         # Order previous samples
         x_old, y_old = previous_samples
         ind = np.argsort(y_old)
         x_old, y_old = x_old[ind], y_old[ind]
         # Select survivers
-        n_survive = int(len(x_old)*survival_rate)
+        n_survive = int(len(x_old) * survival_rate)
         x_survived, y_survived = x_old[:n_survive], y_old[:n_survive]
         # Append
         x = np.append(x, x_survived, axis=0)
         y = np.append(y, y_survived)
         # Return
-        return (x,y)
+        return (x, y)
 
     def determine_gaussian_width(self):
         if isinstance(self.width_scheduler, float):
@@ -344,7 +345,7 @@ def selector_deterministic_linear(algorithm, n, samples, values):
         z = 1 - (z / np.amax(z))
         probabilities = z / np.sum(z)
     else:
-        probabilities = np.ones(len(z))/len(z)
+        probabilities = np.ones(len(z)) / len(z)
 
     # Sort samples based on probability, from low to high
     sortind = np.argsort(probabilities)[::-1]
@@ -352,12 +353,12 @@ def selector_deterministic_linear(algorithm, n, samples, values):
     samples = samples[sortind]
     values = values[sortind]
     probabilities = probabilities[sortind]
-    
+
     # Determine samples per point
-    samples_per_ind = np.ceil(probabilities*n)
+    samples_per_ind = np.ceil(probabilities * n)
 
     # Correct for rounding errors
-    at_least_one = 1.0*(samples_per_ind > 0)
+    at_least_one = 1.0 * (samples_per_ind > 0)
     for i in range(len(at_least_one)):
         potentially_sampled = np.sum(samples_per_ind) - np.sum(at_least_one)
         if potentially_sampled < n:
@@ -367,7 +368,7 @@ def selector_deterministic_linear(algorithm, n, samples, values):
     # Create indices and return values
     indices = []
     for i in range(len(samples_per_ind)):
-        indices.extend([i]*int(samples_per_ind[i]))
+        indices.extend([i] * int(samples_per_ind[i]))
     return (indices, samples, values)
 
 
@@ -382,7 +383,7 @@ def selector_stochastic_linear(algorithm, n, samples, values):
         z = 1 - (z / np.amax(z))
         probabilities = z / np.sum(z)
     else:
-        probabilities = np.ones(len(z))/len(z)
+        probabilities = np.ones(len(z)) / len(z)
     indices = np.random.choice(len(samples), n, p=probabilities.flatten())
     return (indices, samples, values)
 


### PR DESCRIPTION
Several changes and bug fixes to particle filter algorithm:

- implementation of callback for each iteration after the first one
- renaming of weighing to selector and let it output indices of selected samples (instead of selected samples directly)
- fix selector_deterministic_linear
- fix erroneous implementation: best datapoints were notpassed from iteration to iteration