### PR TITLE
Split implementation tests

### DIFF
--- a/tests/test_implementations.py
+++ b/tests/test_implementations.py
@@ -18,42 +18,42 @@ def test_posterior_implementations(tmp_path):
 
 
 def test_optimisation_randomoptimisation(tmp_path):
-    procedure = optimisation.RandomOptimisation(),
+    procedure = optimisation.RandomOptimisation()
     experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
     experiment.run(func.Himmelblau(), finish_line=250)
     shutil.rmtree(str(tmp_path))
 
 
 def test_optimisation_particlefilter(tmp_path):
-    procedure = optimisation.ParticleFilter(),
+    procedure = optimisation.ParticleFilter()
     experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
     experiment.run(func.Himmelblau(), finish_line=250)
     shutil.rmtree(str(tmp_path))
 
 
 def test_optimisation_gpyopt(tmp_path):
-    procedure = optimisation.GPyOpt(),
+    procedure = optimisation.GPyOpt()
     experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
     experiment.run(func.Himmelblau(), finish_line=250)
     shutil.rmtree(str(tmp_path))
 
 
 def test_optimisation_cmae(tmp_path):
-    procedure = optimisation.CMAOptimisation(),
+    procedure = optimisation.CMAOptimisation()
     experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
     experiment.run(func.Himmelblau(), finish_line=250)
     shutil.rmtree(str(tmp_path))
 
 
 def test_optimisation_ampgo(tmp_path):
-    procedure = optimisation.Ampgo(),
+    procedure = optimisation.Ampgo()
     experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
     experiment.run(func.Himmelblau(), finish_line=250)
     shutil.rmtree(str(tmp_path))
 
 
 def test_optimisation_turbo(tmp_path):
-    procedure = optimisation.TuRBO(max_evals=5, n_training_steps=5),
+    procedure = optimisation.TuRBO(max_evals=5, n_training_steps=5)
     experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
     experiment.run(func.Himmelblau(), finish_line=250)
     shutil.rmtree(str(tmp_path))

--- a/tests/test_implementations.py
+++ b/tests/test_implementations.py
@@ -17,20 +17,43 @@ def test_posterior_implementations(tmp_path):
         shutil.rmtree(str(tmp_path))
 
 
-def test_optimisation_implementations(tmp_path):
-    # These are the implementations to test
-    implementations = [
-        optimisation.RandomOptimisation(),
-        optimisation.ParticleFilter(),
-        optimisation.GPyOpt(),
-        optimisation.CMAOptimisation(),
-        optimisation.Ampgo(),
-        optimisation.TuRBO(max_evals=11, n_training_steps=30)
-        # optimisation.Pygmo,  # excluded because of a mandatory install
-        # optimisation.PyScannerBit  # excluded because of a mandatory install
-    ]
+def test_optimisation_randomoptimisation(tmp_path):
+    procedure = optimisation.RandomOptimisation(),
+    experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
+    experiment.run(func.Himmelblau(), finish_line=250)
+    shutil.rmtree(str(tmp_path))
 
-    for procedure in implementations:
-        experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
-        experiment.run(func.Himmelblau(), finish_line=250)
-        shutil.rmtree(str(tmp_path))
+
+def test_optimisation_particlefilter(tmp_path):
+    procedure = optimisation.ParticleFilter(),
+    experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
+    experiment.run(func.Himmelblau(), finish_line=250)
+    shutil.rmtree(str(tmp_path))
+
+
+def test_optimisation_gpyopt(tmp_path):
+    procedure = optimisation.GPyOpt(),
+    experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
+    experiment.run(func.Himmelblau(), finish_line=250)
+    shutil.rmtree(str(tmp_path))
+
+
+def test_optimisation_cmae(tmp_path):
+    procedure = optimisation.CMAOptimisation(),
+    experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
+    experiment.run(func.Himmelblau(), finish_line=250)
+    shutil.rmtree(str(tmp_path))
+
+
+def test_optimisation_ampgo(tmp_path):
+    procedure = optimisation.Ampgo(),
+    experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
+    experiment.run(func.Himmelblau(), finish_line=250)
+    shutil.rmtree(str(tmp_path))
+
+
+def test_optimisation_turbo(tmp_path):
+    procedure = optimisation.TuRBO(max_evals=5, n_training_steps=5),
+    experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
+    experiment.run(func.Himmelblau(), finish_line=250)
+    shutil.rmtree(str(tmp_path))

--- a/tests/test_implementations.py
+++ b/tests/test_implementations.py
@@ -53,7 +53,7 @@ def test_optimisation_ampgo(tmp_path):
 
 
 def test_optimisation_turbo(tmp_path):
-    procedure = optimisation.TuRBO(max_evals=5, n_training_steps=5)
+    procedure = optimisation.TuRBO(max_evals=5, n_training_steps=30)
     experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
     experiment.run(func.Himmelblau(), finish_line=250)
     shutil.rmtree(str(tmp_path))

--- a/tests/test_implementations.py
+++ b/tests/test_implementations.py
@@ -53,7 +53,7 @@ def test_optimisation_ampgo(tmp_path):
 
 
 def test_optimisation_turbo(tmp_path):
-    procedure = optimisation.TuRBO(max_evals=5, n_training_steps=30)
+    procedure = optimisation.TuRBO(max_evals=11, n_training_steps=30)
     experiment = exp.OptimisationExperiment(procedure, str(tmp_path))
     experiment.run(func.Himmelblau(), finish_line=250)
     shutil.rmtree(str(tmp_path))


### PR DESCRIPTION
By splitting the implementation tests for the optimisation procedures, timeouts in Travis are hopefully avoided.